### PR TITLE
feat: add first scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+---
+
+language: ruby
+sudo: required
+
+services:
+  - docker
+
+env:
+  - DISTRIB=debian:jessie
+  - DISTRIB=ubuntu:trusty
+
+install:
+  - gem install serverspec
+
+before_script:
+  - mkdir "$HOME/bin"
+  - curl -Lso "$HOME/bin/shellcheck" https://github.com/caarlos0/shellcheck-docker/releases/download/v0.4.3/shellcheck
+  - chmod +x "$HOME/bin/shellcheck"
+  - export PATH=$PATH:$HOME/bin
+
+script:
+  - make test

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Maxime Loliée <maxime@siliadev.com> (github.com/loliee)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+SHELL := /usr/bin/env bash
+.DEFAULT_GOAL := help
+
+shellcheck: ## Run shellcheck on /scripts directory
+	$(info --> Run shellsheck)
+	find . -type f -name *.sh | xargs -n 1 shellcheck
+
+test: ## Run test suite
+	$(info --> Run test suite)
+	make shellcheck
+	@env \
+		LIMIT= \
+		./tests/run.sh

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
-# install-scripts
-Some bash scripts to install stuffs...
+## install-scripts
+
+[![Build Status](https://travis-ci.org/loliee/install-scripts.svg?branch=master)](https://travis-ci.org/loliee/install-scripts)
+
+Some bash scripts to install apps on Debian/Ubuntu LTS distrib.
+
+## Index
+
+- [albert](albert/)
+- [bats](bats/)
+- [docker](docker/)
+- [etcd](etcd/)
+- [fasd](fasd/)
+- [flannel](flannel/)
+- [fzf](fzf/)
+- [hack-font](hack-font/)
+- [install-ruby](install-ruby/)
+- [kubernetes](kubernetes/)
+- [pip](pip/)
+- [sshrc](sshrc/)
+- [stow](stow/)
+- [tmux](tmux/)
+- [vagrant](vagrant/)
+- [vim](vim/)
+- [xfce-theme](xfce-theme)
+
+## License
+
+MIT © [Maxime Loliée](https://github.com/loliee/)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,11 @@
+require 'rake'
+require 'yaml'
+require 'rspec/core/rake_task'
+
+namespace :serverspec do
+  desc "Run serverspec"
+  RSpec::Core::RakeTask.new('run') do |t|
+    appname = ENV['appname'] || '*'
+    t.pattern = "#{appname}/*_spec.rb"
+  end
+end

--- a/albert/README.md
+++ b/albert/README.md
@@ -1,0 +1,27 @@
+# albert
+
+[![Build Status](https://travis-ci.org/loliee/install-scripts.svg?branch=master)](https://travis-ci.org/loliee/install-scripts)
+
+Install [albert](https://github.com/ManuelSchneid3r/albert).
+
+## Dependencies
+
+Will install the following packages:
+
+- `cmake`
+- `build-essential`
+- `git`
+- `qtbase5-dev`
+- `libqt5svg5-dev`
+- `libqt5x11extras5-dev `
+- `libmuparser-dev`
+
+## Variables
+
+name             | default   | description
+-----------------|-----------|----------------------------------
+`ALBERT_VERSION` | `v0.8.11` | version to install.
+
+## License
+
+MIT © [Maxime Loliée](https://github.com/loliee/)

--- a/albert/albert.sh
+++ b/albert/albert.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+ALBERT_VERSION=${ALBERT_VERSION:-'v0.8.11'}
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Ensure version directory exists
+mkdir -p /root/.versions
+
+# Ensure git is installed
+hash git &>/dev/null || apt-get install -y git
+
+# Ensure make and compilator are installed
+hash make &>/dev/null || apt-get install -y build-essential
+
+# Ensure dependencies are installed
+apt-get install -y \
+                cmake \
+                qtbase5-dev \
+                libqt5x11extras5-dev \
+                libqt5svg5-dev \
+                libmuparser-dev
+
+grep -q "^${ALBERT_VERSION}" /root/.versions/albert &>/dev/null || {
+  if [[ ! -d /usr/local/src/albert ]]; then
+  git clone https://github.com/ManuelSchneid3r/albert.git \
+    /usr/local/src/albert
+  fi
+  pushd "/usr/local/src/albert" &>/dev/null
+    git checkout "$ALBERT_VERSION"
+    cmake . -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release
+    make
+    make install
+  popd &>/dev/null
+  echo "${ALBERT_VERSION}" >/root/.versions/albert
+}

--- a/albert/albert_spec.rb
+++ b/albert/albert_spec.rb
@@ -1,0 +1,17 @@
+require_relative '../tests/spec_helper'
+
+albert_version = 'v0.8.11'
+cname = ENV['container_name']
+
+describe command("docker exec #{cname} cat /root/.versions/albert") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{albert_version}/ }
+end
+
+describe command("docker exec #{cname} ls /usr/bin/albert") do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command("docker exec #{cname} ls /usr/share/albert") do
+  its(:exit_status) { should eq 0 }
+end

--- a/bats/README.md
+++ b/bats/README.md
@@ -1,0 +1,19 @@
+# bats
+
+[![Build Status](https://travis-ci.org/loliee/install-scripts.svg?branch=master)](https://travis-ci.org/loliee/install-scripts)
+
+Install [bats](https://github.com/sstephenson/bats).
+
+## Dependencies
+
+n/a
+
+## Variables
+
+name             | default   | description
+-----------------|-----------|----------------------------------
+`BATS_VERSION` | `0.4.0` | version to install.
+
+## License
+
+MIT © [Maxime Loliée](https://github.com/loliee/)

--- a/bats/bats.sh
+++ b/bats/bats.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+BATS_VERSION=${BATS_VERSION:-'0.4.0'}
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Ensure version directory exists
+mkdir -p /root/.versions
+
+# Ensure curl is installed
+hash git &>/dev/null || apt-get install -y git
+
+grep -q "^${BATS_VERSION}" /root/.versions/bats &>/dev/null || {
+  echo "--> install bats v${BATS_VERSION}..."
+  if [[ ! -d /tmp/bats ]]; then
+    git clone https://github.com/sstephenson/bats.git /tmp/bats
+  fi
+  pushd "/tmp/bats" &>/dev/null
+      git checkout "v${BATS_VERSION}"
+      ./install.sh /usr/local
+      echo "${BATS_VERSION}" > /root/.versions/bats
+  popd &>/dev/null
+}

--- a/bats/bats_spec.rb
+++ b/bats/bats_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../tests/spec_helper'
+
+bats_version = '0.4.0'
+cname = ENV['container_name']
+
+describe command("docker exec #{cname} /usr/local/bin/bats --version") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{bats_version}/ }
+end
+
+describe command("docker exec #{cname} cat /root/.versions/bats") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{bats_version}/ }
+end

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,22 @@
+# docker
+
+[![Build Status](https://travis-ci.org/loliee/install-scripts.svg?branch=master)](https://travis-ci.org/loliee/install-scripts)
+
+Install [docker](https://docs.docker.com/engine/installation) and [docker-compose](https://docs.docker.com/compose/install/).
+
+## Dependencies
+
+- `apt-transport-https`
+- `ca-certificates`
+- `[docker-apt-repository]`
+
+## Variables
+
+name             | default   | description
+-----------------|-----------|----------------------------------
+`DOCKER_VERSION` | `1.12.1` | version to install.
+`DOCKER_COMPOSE_VERSION` | `1.8.0` | version to install.
+
+## License
+
+MIT © [Maxime Loliée](https://github.com/loliee/)

--- a/docker/docker.sh
+++ b/docker/docker.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+DOCKER_VERSION=${DOCKER_VERSION:-'1.12.1'}
+DOCKER_COMPOSE_VERSION=${DOCKER_COMPOSE_VERSION:-'1.8.0'}
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Ensure version directory exists
+mkdir -p /root/.versions
+
+# Ensure git is installed
+hash git &>/dev/null || apt-get install -y git
+
+# Ensure curl is installed
+hash curl &>/dev/null || apt-get install -y curl
+
+# Ensure dependencies are installed
+apt-get install -y \
+  apt-transport-https \
+  aufs-tools \
+  ca-certificates \
+  xz-utils \
+  --no-install-recommends
+
+apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+
+echo "Prepare docker ${DOCKER_VERSION} release ..."
+grep -q "^${DOCKER_VERSION}" /root/.versions/docker &>/dev/null || {
+  # Prepare for docker
+  apt-get purge -f "lxc-docker*" &>/dev/null || true
+  apt-get purge -f "docker.io*" &>/dev/null || true
+  apt-cache policy docker-engine
+  apt-get purge lxc-docker &>/dev/null || true
+
+  # Ubuntu
+  if [[ $(lsb_release -c --short) == 'trusty' ]]; then
+    echo 'docker detected OS "Ubuntu"'
+
+    if [[ ! -f /etc/apt/sources.list.d/docker.list ]]; then
+      echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list
+    fi
+
+    apt-get install -y \
+      "linux-image-extra-$(uname -r)" \
+      "linux-image-extra-virtual"
+
+    # https://github.com/docker/docker/issues/20221
+    rm -rf /var/lib/docker/devicemapper || true
+    rm -rf /var/lib/docker/network || true
+  # Debian
+  elif [ -f "/etc/debian_version" ]; then
+    echo 'docker detected OS "Debian"'
+
+    if [[ ! -f /etc/apt/sources.list.d/docker.list ]]; then
+      echo "deb https://apt.dockerproject.org/repo debian-jessie main" >> /etc/apt/sources.list.d/docker.list
+    fi
+    apt-get install -y linux-headers-amd64
+  fi
+
+  apt-get update
+  apt-get install -y -f docker-engine
+
+  is_loop_device=$(ls /dev/loop* &>/dev/null; echo $?)
+  if [[ "$is_loop_device" != "0" ]]; then
+    for i in {0..6}; do
+      mknod -m0660 /dev/loop$i b 7 $i
+    done
+  fi
+  echo "${DOCKER_VERSION}" >/root/.versions/docker
+}
+
+DOCKER_VERSION="$(uname -s)-$(uname -m)"
+grep -q "^${DOCKER_COMPOSE_VERSION}" /root/.versions/docker-compose &>/dev/null || {
+  echo "--> install docker-compose v${DOCKER_COMPOSE_VERSION}..."
+    curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-${DOCKER_VERSION}" \
+  > /usr/local/bin/docker-compose
+  chmod 755 /usr/local/bin/docker-compose
+  echo "${DOCKER_COMPOSE_VERSION}" > /root/.versions/docker-compose
+}

--- a/docker/docker_spec.rb
+++ b/docker/docker_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../tests/spec_helper'
+
+docker_version = '1.12'
+docker_compose_version = '1.8'
+cname = ENV['container_name']
+
+describe command("docker exec #{cname} docker --version") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{docker_version}/ }
+end
+
+describe command("docker exec #{cname} docker-compose --version") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{docker_compose_version}/ }
+end
+
+describe command("docker exec #{cname} cat /root/.versions/docker") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{docker_version}/ }
+end

--- a/etcd/README.md
+++ b/etcd/README.md
@@ -1,0 +1,19 @@
+# etcd
+
+[![Build Status](https://travis-ci.org/loliee/install-scripts.svg?branch=master)](https://travis-ci.org/loliee/install-scripts)
+
+Install [etcd](https://github.com/coreos/etcd).
+
+## Dependencies
+
+- `upstart`
+
+## Variables
+
+name             | default   | description
+-----------------|-----------|----------------------------------
+`ETCD_VERSION` | `2.3.7` | version to install.
+
+## License
+
+MIT © [Maxime Loliée](https://github.com/loliee/)

--- a/etcd/etcd.sh
+++ b/etcd/etcd.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+ETCD_VERSION=${ETCD_VERSION:-'2.3.7'}
+ETCD="etcd-v${ETCD_VERSION}-linux-amd64"
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Ensure version directory exists
+mkdir -p /root/.versions
+
+# Ensure curl is installed
+hash curl &>/dev/null || apt-get install -y curl
+
+if [ -f "/etc/debian_version" ]; then
+  apt-get install -y upstart
+fi
+
+echo "Prepare etcd ${ETCD_VERSION} release ..."
+grep -q "^${ETCD_VERSION}" /root/.versions/etcd 2>/dev/null || {
+  curl -L -o etcd.tar.gz \
+    "https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/${ETCD}.tar.gz"
+  tar xzf etcd.tar.gz && rm -f etcd.tar.gz
+  cp "${ETCD}/etcd" "${ETCD}/etcdctl" /usr/local/bin/
+  rm -rf "${ETCD}"
+  echo "${ETCD_VERSION}" > /root/.versions/etcd
+}
+
+if [[ ! -f /etc/init/etcd.conf ]]; then
+  cat <<EOT >> "/etc/init/etcd.conf"
+description "Etcd service"
+author "@loliee"
+
+start on (net-device-up
+          and local-filesystems
+          and runlevel [2345])
+
+respawn
+
+limit nofile 65536 65536
+
+pre-start script
+	ETCD=/usr/local/bin/\$UPSTART_JOB
+	if [ -f /etc/default/\$UPSTART_JOB ]; then
+		. /etc/default/\$UPSTART_JOB
+	fi
+	if [ -f \$ETCD ]; then
+		exit 0
+	fi
+    echo "\$ETCD binary not found, exiting"
+    exit 22
+end script
+
+script
+	ETCD=/usr/local/bin/\$UPSTART_JOB
+	ETCD_OPTS=""
+	if [ -f /etc/default/\$UPSTART_JOB ]; then
+		. /etc/default/\$UPSTART_JOB
+	fi
+	exec "\$ETCD" \$ETCD_OPTS
+end script
+EOT
+fi
+
+if [[ ! -f /etc/default/etcd ]]; then
+cat <<EOT >> "/etc/default/etcd"
+ETCD_OPTS=""
+EOT
+fi

--- a/etcd/etcd_spec.rb
+++ b/etcd/etcd_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../tests/spec_helper'
+
+etcd_version = '2.3.7'
+cname = ENV['container_name']
+
+describe command("docker exec #{cname} /usr/local/bin/etcd --version") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{etcd_version}/ }
+end
+
+describe command("docker exec #{cname} cat /root/.versions/etcd") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{etcd_version}/ }
+end
+
+describe command("docker exec #{cname} cat /etc/init/etcd.conf") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /description "Etcd service"/ }
+  its(:stdout) { should match /author "@loliee"/ }
+end
+
+describe command("docker exec #{cname} cat /etc/default/etcd") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /ETCD_OPTS=""/ }
+end

--- a/fasd/README.md
+++ b/fasd/README.md
@@ -1,0 +1,20 @@
+# fasd
+
+[![Build Status](https://travis-ci.org/loliee/install-scripts.svg?branch=master)](https://travis-ci.org/loliee/install-scripts)
+
+Install [fasd](https://github.com/clvv/fasd).
+
+## Dependencies
+
+- `git`
+- `build-essential`
+
+## Variables
+
+name             | default   | description
+-----------------|-----------|----------------------------------
+`FASD_VERSION` | `1.0.1` | version to install.
+
+## License
+
+MIT © [Maxime Loliée](https://github.com/loliee/)

--- a/fasd/fasd.sh
+++ b/fasd/fasd.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+FASD_VERSION=${FASD_VERSION:-'1.0.1'}
+
+# Ensure version directory exists
+mkdir -p /root/.versions
+
+# Ensure curl is installed
+hash git &>/dev/null || apt-get install -y git
+
+# Ensure make and compilator are installed
+hash make &>/dev/null || apt-get install -y build-essential
+
+echo "Prepare fasd ${FASD_VERSION} release ..."
+grep -q "^${FASD_VERSION}" /root/.versions/fasd 2>/dev/null || {
+  if [[ ! -d /usr/local/src/fasd ]]; then
+    echo "--> install fasd ..."
+    git clone https://github.com/clvv/fasd.git /usr/local/src/fasd
+  fi
+  pushd "/usr/local/src/fasd" &>/dev/null
+    git checkout "$FASD_VERSION"
+    make install
+  popd &>/dev/null
+  echo "${FASD_VERSION}" > /root/.versions/fasd
+}

--- a/fasd/fasd_spec.rb
+++ b/fasd/fasd_spec.rb
@@ -1,0 +1,18 @@
+require_relative '../tests/spec_helper'
+
+fasd_version = '1.0.1'
+cname = ENV['container_name']
+
+describe command("docker exec #{cname} /usr/local/bin/fasd --version") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{fasd_version}/ }
+end
+
+describe command("docker exec #{cname} cat /root/.versions/fasd") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{fasd_version}/ }
+end
+
+describe command("docker exec #{cname} ls /usr/local/src/fasd") do
+  its(:exit_status) { should eq 0 }
+end

--- a/flannel/README.md
+++ b/flannel/README.md
@@ -1,0 +1,20 @@
+# flannel
+
+[![Build Status](https://travis-ci.org/loliee/install-scripts.svg?branch=master)](https://travis-ci.org/loliee/install-scripts)
+
+Install [flannel](https://github.com/coreos/flannel).
+
+## Dependencies
+
+- `curl`
+- `upstart`
+
+## Variables
+
+name             | default   | description
+-----------------|-----------|----------------------------------
+`FLANNEL_VERSION` | `0.6.2` | version to install.
+
+## Licence
+
+MIT © [Maxime Loliée](https://github.com/loliee/)

--- a/flannel/flannel.sh
+++ b/flannel/flannel.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+FLANNEL_VERSION=${FLANNEL_VERSION:-"0.6.2"}
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Ensure version directory exists
+mkdir -p /root/.versions
+
+# Ensure curl is installed
+hash curl &>/dev/null || apt-get install -y curl
+
+if [ -f "/etc/debian_version" ]; then
+  apt-get install -y upstart
+fi
+
+echo "Prepare flannel ${FLANNEL_VERSION} release ..."
+grep -q "^${FLANNEL_VERSION}\$" /root/.versions/flannel 2>/dev/null || {
+  curl -L -o flannel.tar.gz \
+    "https://github.com/coreos/flannel/releases/download/v${FLANNEL_VERSION}/flannel-v${FLANNEL_VERSION}-linux-amd64.tar.gz"
+  mkdir -p "flannel-v${FLANNEL_VERSION}-linux-amd64/flanneld"
+  tar xzf flannel.tar.gz -C  "flannel-v${FLANNEL_VERSION}-linux-amd64" && rm -rf flannel.tar.gz
+  cp "flannel-v${FLANNEL_VERSION}-linux-amd64/flanneld" /usr/local/bin/
+  rm -rf "flannel-v${FLANNEL_VERSION}-linux-amd64"
+  echo "${FLANNEL_VERSION}" > /root/.versions/flannel
+}
+
+if [[ ! -f /etc/init/flanneld.conf ]]; then
+  cat <<EOT >> "/etc/init/flanneld.conf"
+description "Flannel service"
+author "@loliee"
+
+respawn
+
+start on started etcd
+stop on stopping etcd
+
+limit nofile 65536 65536
+
+pre-start script
+        FLANNEL=/usr/local/bin/\$UPSTART_JOB
+        if [ -f /etc/default/\$UPSTART_JOB ]; then
+                . /etc/default/\$UPSTART_JOB
+        fi
+        if [ -f \$FLANNEL ]; then
+                exit 0
+        fi
+    exit 22
+end script
+
+script
+        FLANNEL=/usr/local/bin/\$UPSTART_JOB
+        FLANNEL_OPTS=""
+        if [ -f /etc/default/\$UPSTART_JOB ]; then
+                . /etc/default/\$UPSTART_JOB
+        fi
+        exec "\$FLANNEL" \$FLANNEL_OPTS
+end script
+EOT
+fi
+
+if [[ ! -f /etc/default/flanneld ]]; then
+  cat <<EOT >> "/etc/default/flanneld"
+FLANNEL_OPTS=""
+EOT
+fi

--- a/flannel/flannel_spec.rb
+++ b/flannel/flannel_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../tests/spec_helper'
+
+flannel_version = '0.6.2'
+cname = ENV['container_name']
+
+describe command("docker exec #{cname} /usr/local/bin/flanneld --version") do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command("docker exec #{cname} cat /root/.versions/flannel") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{flannel_version}/ }
+end
+
+describe command("docker exec #{cname} cat /etc/init/flanneld.conf") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /description "Flannel service"/ }
+  its(:stdout) { should match /author "@loliee"/ }
+end
+
+describe command("docker exec #{cname} cat /etc/default/flanneld") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /FLANNEL_OPTS=""/ }
+end

--- a/fzf/README.md
+++ b/fzf/README.md
@@ -1,0 +1,22 @@
+# fzf
+
+[![Build Status](https://travis-ci.org/loliee/install-scripts.svg?branch=master)](https://travis-ci.org/loliee/install-scripts)
+
+Install [fzf](https://github.com/junegunn/fzf).
+
+## Dependencies
+
+- `git`
+- `golang`
+- `build-essential`
+- `libncurses5-dev`
+
+## Variables
+
+name             | default   | description
+-----------------|-----------|----------------------------------
+`FZF_VERSION` | `0.15.4` | version to install.
+
+## License
+
+MIT © [Maxime Loliée](https://github.com/loliee/)

--- a/fzf/fzf.sh
+++ b/fzf/fzf.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+FZF_VERSION=${FZF_VERSION:-'0.15.4'}
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Ensure version directory exists
+mkdir -p /root/.versions
+
+# Ensure curl is installed
+hash git &>/dev/null || apt-get install -y git
+
+# Ensure go is installed
+hash golang &>/dev/null || apt-get install -y golang
+
+# Ensure gcc is installed
+hash gcc &>/dev/null || apt-get install -y build-essential
+
+# Ensure dependencies are installed
+apt-get install -y libncurses5-dev
+
+grep -q "^${FZF_VERSION}" /root/.versions/fzf 2>/dev/null || {
+  if [[ ! -d /usr/local/src/fzf ]]; then
+    git clone https://github.com/junegunn/fzf.git /usr/local/src/fzf
+  fi
+  pushd "/usr/local/src/fzf" &>/dev/null
+    git checkout "$FZF_VERSION"
+    ./install --no-completion --key-bindings --no-update-rc
+    ln -sf /usr/local/src/fzf/bin/fzf /usr/local/bin/fzf
+    ln -sf /usr/local/src/fzf/bin/fzf-tmux /usr/local/bin/fzf-tmux
+  popd &>/dev/null
+  echo "${FZF_VERSION}" > /root/.versions/fzf
+}

--- a/fzf/fzf_spec.rb
+++ b/fzf/fzf_spec.rb
@@ -1,0 +1,18 @@
+require_relative '../tests/spec_helper'
+
+fzf_version = '0.15.4'
+cname = ENV['container_name']
+
+describe command("docker exec #{cname} /usr/local/bin/fzf --version") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{fzf_version}/ }
+end
+
+describe command("docker exec #{cname} cat /root/.versions/fzf") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{fzf_version}/ }
+end
+
+describe command("docker exec #{cname} ls /usr/local/src/fzf") do
+  its(:exit_status) { should eq 0 }
+end

--- a/hack-font/README.md
+++ b/hack-font/README.md
@@ -1,0 +1,20 @@
+# hack-font
+
+[![Build Status](https://travis-ci.org/loliee/install-scripts.svg?branch=master)](https://travis-ci.org/loliee/install-scripts)
+
+Install [hack-font](https://github.com/chrissimpkins/Hack).
+
+## Dependencies
+
+- `curl`
+- `unzip`
+
+## Variables
+
+name             | default   | description
+-----------------|-----------|----------------------------------
+`HACK_VERSION` | `2.020` | version to install.
+
+## License
+
+MIT © [Maxime Loliée](https://github.com/loliee/)

--- a/hack-font/hack-font.sh
+++ b/hack-font/hack-font.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+HACK_VERSION=${HACK_VERSION:-'2.020'}
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Ensure version directory exists
+mkdir -p /root/.versions
+
+# Ensure curl is installed
+hash curl &>/dev/null || apt-get install -y curl
+
+# Ensure unzip is installed
+hash unzip &>/dev/null || apt-get install -y unzip
+
+grep -q "^${HACK_VERSION}" /root/.versions/hack-font &>/dev/null || {
+  if [[ ! -f "/tmp/hack-${HACK_VERSION}-ttf.zip" ]]; then
+  echo "--> install hack font v${HACK_VERSION}..."
+    curl -o "/tmp/hack-${HACK_VERSION}-ttf.zip" \
+      -L "https://github.com/chrissimpkins/Hack/releases/download/v${HACK_VERSION}/Hack-v${HACK_VERSION/./_}-ttf.zip"
+  fi
+  unzip -d /usr/share/fonts/ "/tmp/hack-${HACK_VERSION}-ttf.zip"
+  ls /usr/share/fonts/
+  echo "${HACK_VERSION}" > /root/.versions/hack-font
+}

--- a/hack-font/hack-font_spec.rb
+++ b/hack-font/hack-font_spec.rb
@@ -1,0 +1,17 @@
+require_relative '../tests/spec_helper'
+
+hack_version = '2.020'
+cname = ENV['container_name']
+
+describe command("docker exec #{cname} ls /usr/share/fonts/") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /Hack-Bold.ttf/ }
+  its(:stdout) { should match /Hack-BoldItalic.ttf/ }
+  its(:stdout) { should match /Hack-Italic.ttf/ }
+  its(:stdout) { should match /Hack-Regular.ttf/ }
+end
+
+describe command("docker exec #{cname} cat /root/.versions/hack-font") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{hack_version}/ }
+end

--- a/install-ruby/README.md
+++ b/install-ruby/README.md
@@ -1,0 +1,25 @@
+# install-ruby
+
+[![Build Status](https://travis-ci.org/loliee/install-scripts.svg?branch=master)](https://travis-ci.org/loliee/install-scripts)
+
+Install [install-ruby](https://github.com/coreos/install-ruby), [chruby](https://github.com/postmodern/chruby) and 
+finally [ruby](https://www.ruby-lang.org/en/).
+
+## Dependencies
+
+- `curl`
+- `build-essential`
+
+## Variables
+
+name             | default   | description
+-----------------|-----------|----------------------------------
+`CUSER` | `root` | username where rubies will be installed.
+`CHRUBY_VERSION` | `0.3.9` | chruby version.
+`GEM_LIST`       | `empty`  | list of gem to install sperated by a coma.
+`RUBY_VERSION` | `2.3.1` | ruby version.
+`INSTALL_RUBY_VERSION` | `0.6.0` | ruby-install version.
+
+## License
+
+MIT © [Maxime Loliée](https://github.com/loliee/)

--- a/install-ruby/install-ruby.sh
+++ b/install-ruby/install-ruby.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+CUSER=${CUSER:-'root'}
+CHRUBY_VERSION=${CHRUBY_VERSION:-'0.3.9'}
+GEM_LIST=${GEM_LIST:-}
+RUBY_VERSION=${RUBY_VERSION:-'2.3.1'}
+INSTALL_RUBY_VERSION=${INSTALL_RUBY_VERSION:-'0.6.0'}
+RUBIES=(
+ "$RUBY_VERSION"
+)
+
+export DEBIAN_FRONTEND=noninteractive
+
+export PATH=/usr/local/src/ruby-${RUBY_VERSION}/bin/:$PATH
+
+# Ensure version directory exists
+mkdir -p /root/.versions
+
+# Ensure curl is installed
+hash curl &>/dev/null || apt-get install -y curl
+
+# Ensure make and compilator are installed
+hash make &>/dev/null || apt-get install -y build-essential
+
+curl -L -o "postmodern.asc" \
+            https://raw.github.com/postmodern/postmodern.github.io/master/postmodern.asc
+gpg --import postmodern.asc
+
+grep -q "^${CHRUBY_VERSION}" /root/.versions/chruby &>/dev/null || {
+  echo "--> install chruby v${CHRUBY_VERSION}..."
+  if [[ ! -f "/tmp/chruby-${CHRUBY_VERSION}.tar.gz" ]]; then
+    curl -L -o "/tmp/chruby-${CHRUBY_VERSION}.tar.gz" \
+      "https://github.com/postmodern/chruby/archive/v${CHRUBY_VERSION}.tar.gz"
+    curl -L -o "/tmp/chruby-${CHRUBY_VERSION}.tar.gz.asc" \
+      "https://raw.github.com/postmodern/chruby/master/pkg/chruby-${CHRUBY_VERSION}.tar.gz.asc"
+  fi
+  pushd "/tmp/" &>/dev/null
+    #gpg --verify "chruby-${CHRUBY_VERSION}.tar.gz.asc" "chruby-${CHRUBY_VERSION}.tar.gz"
+    tar xvfz "/tmp/chruby-${CHRUBY_VERSION}.tar.gz"
+    pushd "chruby-${CHRUBY_VERSION}" &>/dev/null
+      ./scripts/setup.sh
+    popd &>/dev/null
+  popd &>/dev/null
+  echo "${CHRUBY_VERSION}" >/root/.versions/chruby
+}
+
+grep -q "^${INSTALL_RUBY_VERSION}" /root/.versions/install-ruby &>/dev/null || {
+  echo "--> install install-ruby v${INSTALL_RUBY_VERSION}..."
+  if [[ ! -f "/tmp/install-ruby-${INSTALL_RUBY_VERSION}.tar.gz" ]]; then
+    curl -L -o "/tmp/install-ruby-${INSTALL_RUBY_VERSION}.tar.gz" \
+      "https://github.com/postmodern/ruby-install/archive/v${INSTALL_RUBY_VERSION}.tar.gz"
+    curl -L -o "/tmp/install-ruby-${INSTALL_RUBY_VERSION}.tar.gz.asc" \
+      "https://raw.github.com/postmodern/ruby-install/master/pkg/ruby-install-${INSTALL_RUBY_VERSION}.tar.gz.asc"
+  fi
+  pushd "/tmp/" &>/dev/null
+    #gpg --verify "ruby-install-${INSTALL_RUBY_VERSION}.tar.gz.asc" "ruby-install-${INSTALL_RUBY_VERSION}.tar.gz"
+    tar xvfz "/tmp/install-ruby-${INSTALL_RUBY_VERSION}.tar.gz"
+    rm -rf /usr/local/src/install-ruby &>/dev/null
+    mv "ruby-install-${INSTALL_RUBY_VERSION}" /usr/local/src/install-ruby
+    pushd "/usr/local/src/install-ruby" &>/dev/null
+      make install
+      mkdir -p ~/.rubies
+      RUBIES=(
+        $RUBY_VERSION
+      )
+      if [[ ${CUSER} == 'root' ]]; then
+        user_home='/root'
+      else
+        user_home="/home/${CUSER}"
+      fi
+      for ruby in "${RUBIES[@]}"; do
+        ruby-install --no-reinstall --rubies-dir "${user_home}/.rubies" \
+        ruby "$ruby"
+      done
+      echo "${RUBIES[@]:(-1)}" > "${user_home}/.ruby-version"
+      echo "${INSTALL_RUBY_VERSION}" >/root/.versions/install-ruby
+    popd &>/dev/null
+  popd &>/dev/null
+}
+
+if [[ ! -z $GEM_LIST ]]; then
+  gem_list_array=(${GEM_LIST//,/ })
+  for i in "${!gem_list_array[@]}"; do
+    gem install "${gem_list_array[i]}"
+  done
+fi

--- a/install-ruby/install-ruby_spec.rb
+++ b/install-ruby/install-ruby_spec.rb
@@ -1,0 +1,29 @@
+require_relative '../tests/spec_helper'
+
+ruby_version = '2.3.1'
+install_ruby_version = '0.6.0'
+chruby_version=-'0.3.9'
+cname = ENV['container_name']
+
+describe command("docker exec #{cname} /root/.rubies/ruby-2.3.1/bin/ruby --version") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{ruby_version}/ }
+end
+
+describe command("docker exec #{cname} cat /root/.versions/chruby") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{chruby_version}/ }
+end
+
+describe command("docker exec #{cname} cat /root/.versions/install-ruby") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{install_ruby_version}/ }
+end
+describe command("docker exec #{cname} ls /usr/local/share/chruby") do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command("docker exec #{cname} cat /root/.ruby-version") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{ruby_version}/ }
+end

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,20 @@
+# kubernetes
+
+[![Build Status](https://travis-ci.org/loliee/install-scripts.svg?branch=master)](https://travis-ci.org/loliee/install-scripts)
+
+Install [kubernetes](https://github.com/kubernetes/kubernetes).
+
+## Dependencies
+
+- `curl`
+- `upstart`
+
+## Variables
+
+name             | default   | description
+-----------------|-----------|----------------------------------
+`KUBERNETES_VERSION` | `1.3.8` | version to install.
+
+## License
+
+MIT © [Maxime Loliée](https://github.com/loliee/)

--- a/kubernetes/kubernetes.sh
+++ b/kubernetes/kubernetes.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+export KUBE_VERSION=${KUBE_VERSION:-'1.3.8'}
+
+# Then the role variable defines the role of above machine in the same order, “ai” stands for machine acts as both master
+# and node, “a” stands for master, “i” stands for node.
+export KUBE_ROLE=${KUBE_ROLE:-'ai'}
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Ensure version directory exists
+mkdir -p /root/.versions
+
+# Ensure curl is installed
+hash curl &>/dev/null || apt-get install -y curl
+
+if [ -f "/etc/debian_version" ]; then
+  apt-get install -y upstart
+fi
+
+function get_latest_version_number {
+  curl -Ss "https://storage.googleapis.com/kubernetes-release/release/stable.txt"
+}
+
+if [[ -z "$KUBE_VERSION" ]]; then
+  KUBE_VERSION=$(get_latest_version_number | sed 's/^v//')
+fi
+
+echo "Prepare kubernetes ${KUBE_VERSION} release ..."
+grep -q "^${KUBE_VERSION}\$" /root/.versions/kubernetes 2>/dev/null || {
+  mkdir -p /etc/kubernetes/manifests
+  curl -L -o kubernetes.tar.gz \
+    "https://github.com/kubernetes/kubernetes/releases/download/v${KUBE_VERSION}/kubernetes.tar.gz"
+  tar xzf kubernetes.tar.gz && rm -f kubernetes.tar.gz
+  pushd kubernetes/server
+    tar xzf kubernetes-server-linux-amd64.tar.gz && rm -f kubernetes-server-linux-amd64.tar.gz
+  popd
+
+  if [[ "${KUBE_ROLE}" == *"a"* ]]; then
+    cp kubernetes/server/kubernetes/server/bin/kube-apiserver \
+       kubernetes/server/kubernetes/server/bin/kube-controller-manager \
+       kubernetes/server/kubernetes/server/bin/kube-scheduler \
+       kubernetes/server/kubernetes/server/bin/kubectl /usr/local/bin/
+  fi
+
+  if [[ "${KUBE_ROLE}" == *"i"* ]]; then
+    cp kubernetes/server/kubernetes/server/bin/kubelet \
+       kubernetes/server/kubernetes/server/bin/kube-proxy /usr/local/bin/
+  fi
+  rm -rf kubernetes
+  echo "${KUBE_VERSION}" > /root/.versions/kubernetes
+}
+
+# Master - Api server
+if [[ ! -f /etc/init/kube-apiserver.conf ]]; then
+  cat <<EOT >> "/etc/init/kube-apiserver.conf"
+description "Kube-Apiserver service"
+author "@loliee"
+
+respawn
+
+start on started etcd
+stop on stopping etcd
+
+limit nofile 65536 65536
+
+pre-start script
+	KUBE_APISERVER=/usr/local/bin/\$UPSTART_JOB
+	if [ -f /etc/default/\$UPSTART_JOB ]; then
+		. /etc/default/\$UPSTART_JOB
+	fi
+	if [ -f \$KUBE_APISERVER ]; then
+		exit 0
+	fi
+    exit 22
+end script
+
+script
+	KUBE_APISERVER=/usr/local/bin/\$UPSTART_JOB
+	KUBE_APISERVER_OPTS=""
+	if [ -f /etc/default/\$UPSTART_JOB ]; then
+		. /etc/default/\$UPSTART_JOB
+	fi
+	exec "\$KUBE_APISERVER" \$KUBE_APISERVER_OPTS
+end script
+EOT
+fi
+if [[ ! -f /etc/default/kube-apiserver ]] && [[ "${KUBE_ROLE}" == *"a"* ]]; then
+  cat <<EOT >> "/etc/default/kube-apiserver"
+KUBE_APISERVER_OPTS=""
+EOT
+fi
+
+# Master - Controller Manager
+if [[ ! -f /etc/init/kube-controller-manager.conf ]]; then
+  cat <<EOT >> "/etc/init/kube-controller-manager.conf"
+description "Kube-Controller-Manager service"
+author "@loliee"
+
+respawn
+
+start on started etcd
+stop on stopping etcd
+
+limit nofile 65536 65536
+
+pre-start script
+	KUBE_CONTROLLER_MANAGER=/usr/local/bin/\$UPSTART_JOB
+	if [ -f /etc/default/\$UPSTART_JOB ]; then
+		. /etc/default/\$UPSTART_JOB
+	fi
+	if [ -f \$KUBE_CONTROLLER_MANAGER ]; then
+		exit 0
+	fi
+    exit 22
+end script
+
+script
+	KUBE_CONTROLLER_MANAGER=/usr/local/bin/\$UPSTART_JOB
+	KUBE_CONTROLLER_MANAGER_OPTS=""
+	if [ -f /etc/default/\$UPSTART_JOB ]; then
+		. /etc/default/\$UPSTART_JOB
+	fi
+	exec "\$KUBE_CONTROLLER_MANAGER" \$KUBE_CONTROLLER_MANAGER_OPTS
+end script
+EOT
+fi
+if [[ ! -f /etc/default/kube-controller-manager ]] && [[ "${KUBE_ROLE}" == *"a"* ]]; then
+  cat <<EOT >> "/etc/default/kube-controller-manager"
+KUBE_CONTROLLER_MANAGER_OPTS=""
+EOT
+fi
+
+# Master - Scheduler
+if [[ ! -f /etc/init/kube-scheduler.conf ]]; then
+  cat <<EOT >> "/etc/init/kube-scheduler.conf"
+description "Kube-Scheduler service"
+author "@loliee"
+
+respawn
+
+start on started etcd
+stop on stopping etcd
+
+limit nofile 65536 65536
+
+pre-start script
+	KUBE_SCHEDULER=/usr/local/bin/\$UPSTART_JOB
+	if [ -f /etc/default/\$UPSTART_JOB ]; then
+		. /etc/default/\$UPSTART_JOB
+	fi
+	if [ -f \$KUBE_SCHEDULER ]; then
+		exit 0
+	fi
+    exit 22
+end script
+
+script
+	KUBE_SCHEDULER=/usr/local/bin/\$UPSTART_JOB
+	KUBE_SCHEDULER_OPTS=""
+	if [ -f /etc/default/\$UPSTART_JOB ]; then
+		. /etc/default/\$UPSTART_JOB
+	fi
+	exec "\$KUBE_SCHEDULER" \$KUBE_SCHEDULER_OPTS
+end script
+EOT
+fi
+if [[ ! -f /etc/default/kube-scheduler ]] && [[ "${KUBE_ROLE}" == *"a"* ]]; then
+  cat <<EOT >> "/etc/default/kube-scheduler"
+KUBE_SCHEDULER_OPTS=""
+EOT
+fi
+
+# Minion - Proxy
+if [[ ! -f /etc/init/kube-proxy.conf ]]; then
+  cat <<EOT >> "/etc/init/kube-proxy.conf"
+description "Kube-Proxy service"
+author "@loliee"
+
+respawn
+
+start on started flanneld
+stop on stopping flanneld
+
+limit nofile 65536 65536
+
+pre-start script
+	KUBE_PROXY=/usr/local/bin/\$UPSTART_JOB
+	if [ -f /etc/default/\$UPSTART_JOB ]; then
+		. /etc/default/\$UPSTART_JOB
+	fi
+	if [ -f \$KUBE_PROXY ]; then
+		exit 0
+	fi
+    exit 22
+end script
+
+script
+	KUBE_PROXY=/usr/local/bin/\$UPSTART_JOB
+	KUBE_PROXY_OPTS=""
+	if [ -f /etc/default/\$UPSTART_JOB ]; then
+		. /etc/default/\$UPSTART_JOB
+	fi
+	exec "\$KUBE_PROXY" \$KUBE_PROXY_OPTS
+end script
+EOT
+fi
+if [[ ! -f /etc/default/kube-proxy ]] && [[ "${KUBE_ROLE}" == *"i"* ]]; then
+  cat <<EOT >> "/etc/default/kube-proxy"
+KUBE_PROXY_OPTS=""
+EOT
+fi
+
+# Minion - Kubelet
+if [[ ! -f /etc/init/kubelet.conf ]]; then
+  cat <<EOT >> "/etc/init/kubelet.conf"
+description "Kubelet service"
+author "@loliee"
+
+respawn
+
+start on started flanneld
+stop on stopping flanneld
+
+limit nofile 65536 65536
+
+pre-start script
+	KUBELET=/usr/local/bin/\$UPSTART_JOB
+	if [ -f /etc/default/\$UPSTART_JOB ]; then
+		. /etc/default/\$UPSTART_JOB
+	fi
+	if [ -f \$KUBELET ]; then
+		exit 0
+	fi
+    exit 22
+end script
+
+script
+	KUBELET=/usr/local/bin/\$UPSTART_JOB
+	KUBELET_OPTS=""
+	if [ -f /etc/default/\$UPSTART_JOB ]; then
+		. /etc/default/\$UPSTART_JOB
+	fi
+	exec "\$KUBELET" \$KUBELET_OPTS
+end script
+EOT
+fi
+if [[ ! -f /etc/default/kubelet ]] && [[ "${KUBE_ROLE}" == *"i"* ]]; then
+  cat <<EOT >> "/etc/default/kubelet"
+KUBELET_OPTS=""
+EOT
+fi

--- a/kubernetes/kubernetes_spec.rb
+++ b/kubernetes/kubernetes_spec.rb
@@ -1,0 +1,84 @@
+require_relative '../tests/spec_helper'
+
+kubernetes_version = '1.3.8'
+cname = ENV['container_name']
+
+describe command("docker exec #{cname} cat /root/.versions/kubernetes") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{kubernetes_version}/ }
+end
+
+describe command("docker exec #{cname} ls /usr/local/bin/kube-apiserver") do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command("docker exec #{cname} cat /etc/init/kube-apiserver.conf") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /description "Kube-Apiserver service"/ }
+  its(:stdout) { should match /author "@loliee"/ }
+end
+
+describe command("docker exec #{cname} cat /etc/default/kube-apiserver") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /KUBE_APISERVER_OPTS=""/ }
+end
+
+describe command("docker exec #{cname} ls /usr/local/bin/kube-controller-manager") do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command("docker exec #{cname} cat /etc/init/kube-controller-manager.conf") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /description "Kube-Controller-Manager service"/ }
+  its(:stdout) { should match /author "@loliee"/ }
+end
+
+describe command("docker exec #{cname} cat /etc/default/kube-controller-manager") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /KUBE_CONTROLLER_MANAGER_OPTS=""/ }
+end
+
+describe command("docker exec #{cname} ls /usr/local/bin/kube-scheduler") do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command("docker exec #{cname} cat /etc/init/kube-scheduler.conf") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /description "Kube-Scheduler service"/ }
+  its(:stdout) { should match /author "@loliee"/ }
+end
+
+describe command("docker exec #{cname} cat /etc/default/kube-scheduler") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /KUBE_SCHEDULER_OPTS=""/ }
+end
+
+describe command("docker exec #{cname} ls /usr/local/bin/kube-proxy") do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command("docker exec #{cname} cat /etc/init/kube-proxy.conf") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /description "Kube-Proxy service"/ }
+  its(:stdout) { should match /author "@loliee"/ }
+end
+
+describe command("docker exec #{cname} cat /etc/default/kube-proxy") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /KUBE_PROXY_OPTS=""/ }
+end
+
+describe command("docker exec #{cname} ls /usr/local/bin/kubelet") do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command("docker exec #{cname} cat /etc/init/kubelet.conf") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /description "Kubelet service"/ }
+  its(:stdout) { should match /author "@loliee"/ }
+end
+
+describe command("docker exec #{cname} cat /etc/default/kubelet") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /KUBELET_OPTS=""/ }
+end

--- a/pip/README.md
+++ b/pip/README.md
@@ -1,0 +1,17 @@
+# pip
+
+[![Build Status](https://travis-ci.org/loliee/install-scripts.svg?branch=master)](https://travis-ci.org/loliee/install-scripts)
+
+Install [pip](https://pypi.python.org/pypi/pip).
+
+## Dependencies
+
+- `python`
+
+## Variables
+
+n/a
+
+## License
+
+MIT © [Maxime Loliée](https://github.com/loliee/)

--- a/pip/pip.sh
+++ b/pip/pip.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Ensure curl is installed
+hash curl &>/dev/null || apt-get install -y curl
+
+# Ensure python is installed
+hash python &>/dev/null || apt-get install -y python
+
+echo "--> install pip..."
+hash pip &>/dev/null || {
+  curl -o /tmp/get-pip.py -L "https://bootstrap.pypa.io/get-pip.py"
+  python /tmp/get-pip.py
+}

--- a/pip/pip_spec.rb
+++ b/pip/pip_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../tests/spec_helper'
+
+pip_version = '8.1'
+cname = ENV['container_name']
+
+describe command("docker exec #{cname} pip --version") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{pip_version}/ }
+end

--- a/sshrc/README.md
+++ b/sshrc/README.md
@@ -1,0 +1,17 @@
+# sshrc
+
+[![Build Status](https://travis-ci.org/loliee/install-scripts.svg?branch=master)](https://travis-ci.org/loliee/install-scripts)
+
+Install [pip](https://github.com/Russell91/sshrc).
+
+## Dependencies
+
+- `curl`
+
+## Variables
+
+n/a
+
+## License
+
+MIT © [Maxime Loliée](https://github.com/loliee/)

--- a/sshrc/sshrc.sh
+++ b/sshrc/sshrc.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Ensure curl is installed
+hash curl &>/dev/null || apt-get install -y curl
+
+curl -o /usr/local/bin/sshrc -L \
+  https://raw.githubusercontent.com/Russell91/sshrc/master/sshrc
+chmod +x /usr/local/bin/sshrc

--- a/sshrc/sshrc_spec.rb
+++ b/sshrc/sshrc_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../tests/spec_helper'
+
+cname = ENV['container_name']
+
+describe command("docker exec #{cname} ls /usr/local/bin/sshrc") do
+  its(:exit_status) { should eq 0 }
+end

--- a/stow/README.md
+++ b/stow/README.md
@@ -1,0 +1,20 @@
+# stow
+
+[![Build Status](https://travis-ci.org/loliee/install-scripts.svg?branch=master)](https://travis-ci.org/loliee/install-scripts)
+
+Install [stow](https://www.gnu.org/software/stow/).
+
+## Dependencies
+
+- `curl`
+- `build-essential`
+
+## Variables
+
+name             | default   | description
+-----------------|-----------|----------------------------------
+`STOW_VERSION` | `2.2.2` | version to install.
+
+## License
+
+MIT © [Maxime Loliée](https://github.com/loliee/)

--- a/stow/stow.sh
+++ b/stow/stow.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+STOW_VERSION=${STOW_VERSION:-'2.2.2'}
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Ensure version directory exists
+mkdir -p /root/.versions
+
+# Ensure curl is installed
+hash curl &>/dev/null || apt-get install -y curl
+
+# Ensure gcc is installed
+hash gcc &>/dev/null || apt-get install -y build-essential
+
+grep -q "^${STOW_VERSION}" /root/.versions/stow &>/dev/null || {
+  echo "--> install stow v${STOW_VERSION}..."
+  apt-get purge -f -y stow || true
+  if [[ ! -f "/tmp/stow-${STOW_VERSION}.tar.gz" ]]; then
+    curl -L -o "/tmp/stow-${STOW_VERSION}.tar.gz" \
+      "http://ftp.gnu.org/gnu/stow/stow-${STOW_VERSION}.tar.gz"
+  fi
+  pushd "/tmp/" &>/dev/null
+    tar xvfz "/tmp/stow-${STOW_VERSION}.tar.gz"
+    rm -rf /usr/local/src/stow &>/dev/null
+    mv "stow-${STOW_VERSION}" /usr/local/src/stow
+    pushd "/usr/local/src/stow" &>/dev/null
+      ./configure
+      make install
+      echo "${STOW_VERSION}" > /root/.versions/stow
+    popd &>/dev/null
+  popd &>/dev/null
+}

--- a/stow/stow_spec.rb
+++ b/stow/stow_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../tests/spec_helper'
+
+stow_version = '2.2.2'
+cname = ENV['container_name']
+
+describe command("docker exec #{cname} /usr/local/bin/stow --version") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{stow_version}/ }
+end
+
+describe command("docker exec #{cname} cat /root/.versions/stow") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{stow_version}/ }
+end

--- a/tests/Rakefile
+++ b/tests/Rakefile
@@ -1,0 +1,11 @@
+require 'rake'
+require 'yaml'
+require 'rspec/core/rake_task'
+
+namespace :serverspec do
+  desc "Run serverspec"
+  RSpec::Core::RakeTask.new('run') do |t|
+    appname = ENV['appname'] || '*'
+    t.pattern = "#{appname}/*_spec.rb"
+  end
+end

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+LIMIT=${LIMIT:-''}
+DISTRIB=${DISTRIB-'debian:jessie'}
+
+export SPEC_OPTS='--format documentation --color'
+
+for file in ./*/*.sh; do
+  if [[ "$file" == **"${LIMIT}"** ]] && [[ "$file" != **"/tests/"** ]]; then
+    echo "$file"
+    appname="$(echo "$file" | awk '{split($0,a,"/"); print a[2]}')"
+    container_name=${DISTRIB/:/-}-${appname}
+    export appname \
+         container_name
+
+    echo "--> Run docker ${container_name}"
+    docker run -d --name "${container_name}" -v "${PWD}:/scripts" "${DISTRIB}" tail -f /dev/null
+    docker exec "${container_name}" apt-get update
+    docker exec "${container_name}" "/scripts/${appname}/${appname}.sh"
+    rake serverspec:run
+    docker rm -f "${container_name}"
+  fi
+done

--- a/tests/spec_helper.rb
+++ b/tests/spec_helper.rb
@@ -1,0 +1,6 @@
+require 'serverspec'
+require 'tempfile'
+
+set :backend, :exec
+set :path, '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH'
+set :request_pty, true

--- a/tmux/README.md
+++ b/tmux/README.md
@@ -1,0 +1,22 @@
+# tmux
+
+[![Build Status](https://travis-ci.org/loliee/install-scripts.svg?branch=master)](https://travis-ci.org/loliee/install-scripts)
+
+Install [tmux](https://tmux.github.io/).
+
+## Dependencies
+
+- `curl`
+- `build-essential`
+- `libevent-dev`
+- `libncurses5-dev`
+
+## Variables
+
+name             | default   | description
+-----------------|-----------|----------------------------------
+`TMUX_VERSION` | `2.3` | version to install.
+
+## License
+
+MIT © [Maxime Loliée](https://github.com/loliee/)

--- a/tmux/tmux.sh
+++ b/tmux/tmux.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+TMUX_VERSION=${TMUX_VERSION:-'2.3'}
+
+# Ensure version directory exists
+mkdir -p /root/.versions
+
+# Ensure curl is installed
+hash curl &>/dev/null || apt-get install -y curl
+
+# Ensure dependencies are installed
+apt-get install -y libevent-dev \
+                   libncurses5-dev
+
+# Ensure build-essential is installed
+hash gcc &>/dev/null || apt-get install -y build-essential
+hash make &>/dev/null || apt-get install -y build-essential
+
+grep -q "^${TMUX_VERSION}" /root/.versions/tmux &>/dev/null || {
+  apt-get purge -f -y tmux || true
+  echo "--> install tmux v${TMUX_VERSION}..."
+  if [[ ! -f "/tmp/tmux-${TMUX_VERSION}.tar.gz" ]]; then
+    curl -L -o "/tmp/tmux-${TMUX_VERSION}.tar.gz" \
+      "https://github.com/tmux/tmux/releases/download/${TMUX_VERSION}/tmux-${TMUX_VERSION}.tar.gz"
+  fi
+  pushd "/tmp/" &>/dev/null
+    tar xvfz "tmux-${TMUX_VERSION}.tar.gz"
+    rm -rf /usr/local/src/tmux &>/dev/null || true
+    mv "tmux-${TMUX_VERSION}" /usr/local/src/tmux
+    pushd "/usr/local/src/tmux" &>/dev/null
+      ./configure && make
+      make install
+      echo "${TMUX_VERSION}" > /root/.versions/tmux
+    popd &>/dev/null
+  popd &>/dev/null
+}

--- a/tmux/tmux_spec.rb
+++ b/tmux/tmux_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../tests/spec_helper'
+
+tmux_version = '2.3'
+cname = ENV['container_name']
+
+describe command("docker exec #{cname} cat /root/.versions/tmux") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{tmux_version}/ }
+end
+
+describe command("docker exec #{cname} ls /usr/local/src/tmux") do
+  its(:exit_status) { should eq 0 }
+end

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,0 +1,19 @@
+# vagrant
+
+[![Build Status](https://travis-ci.org/loliee/install-scripts.svg?branch=master)](https://travis-ci.org/loliee/install-scripts)
+
+Install [vagrant](https://github.com/mitchellh/vagrant).
+
+## Dependencies
+
+- `curl`
+
+## Variables
+
+name             | default   | description
+-----------------|-----------|----------------------------------
+`VAGRANT_VERSION` | `1.8.5` | version to install.
+
+## License
+
+MIT © [Maxime Loliée](https://github.com/loliee/)

--- a/vagrant/vagrant.sh
+++ b/vagrant/vagrant.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+VAGRANT_VERSION=${VAGRANT_VERSION:-'1.8.5'}
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Ensure version directory exists
+mkdir -p /root/.versions
+
+# Ensure curl is installed
+hash curl &>/dev/null || apt-get install -y curl
+
+echo "Prepare vagrant ${VAGRANT_VERSION} release ..."
+grep -q "^${VAGRANT_VERSION}" /root/.versions/vagrant 2>/dev/null || {
+  if [[ ! -f "/tmp/vagrant-${VAGRANT_VERSION}.deb" ]]; then
+    curl -o "/tmp/vagrant-${VAGRANT_VERSION}.deb" \
+    "https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_x86_64.deb"
+  fi
+  dpkg -i "/tmp/vagrant-${VAGRANT_VERSION}.deb"
+  echo "${VAGRANT_VERSION}" > /root/.versions/vagrant
+}

--- a/vagrant/vagrant_spec.rb
+++ b/vagrant/vagrant_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../tests/spec_helper'
+
+vagrant_version = '1.8.5'
+cname = ENV['container_name']
+
+describe command("docker exec #{cname} vagrant --version") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{vagrant_version}/ }
+end
+
+describe command("docker exec #{cname} cat /root/.versions/vagrant") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{vagrant_version}/ }
+end

--- a/vim/README.md
+++ b/vim/README.md
@@ -1,0 +1,21 @@
+# vim
+
+[![Build Status](https://travis-ci.org/loliee/install-scripts.svg?branch=master)](https://travis-ci.org/loliee/install-scripts)
+
+Install [vim](http://www.vim.org/).
+
+## Dependencies
+
+- `curl`
+- `build-essential`
+- `libncurses5-dev`
+
+## Variables
+
+name             | default   | description
+-----------------|-----------|----------------------------------
+`VIM_VERSION` | `8.0.0022` | version to install.
+
+## License
+
+MIT © [Maxime Loliée](https://github.com/loliee/)

--- a/vim/vim.sh
+++ b/vim/vim.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+VIM_VERSION=${VIM_VERSION:-'8.0.0022'}
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Ensure version directory exists
+mkdir -p /root/.versions
+
+# Ensure curl is installed
+hash curl &>/dev/null || apt-get install -y curl
+
+# Ensure make and compilator are installed
+hash make &>/dev/null || apt-get install -y build-essential
+
+# Ensure dependencies are installed
+apt-get install -y libncurses5-dev
+
+grep -q "^${VIM_VERSION}" /root/.versions/vim &>/dev/null || {
+  apt-get purge -f -y vim vim-runtime gvim || true
+  echo "--> install vim v${VIM_VERSION}..."
+  if [[ ! -f "/tmp/vim-${VIM_VERSION}.tar.gz" ]]; then
+    curl -o "/tmp/vim-${VIM_VERSION}.tar.gz" \
+      -L "https://github.com/vim/vim/archive/v${VIM_VERSION}.tar.gz"
+  fi
+  pushd "/tmp/" &>/dev/null
+    tar xvfz "/tmp/vim-${VIM_VERSION}.tar.gz"
+    rm -rf /usr/local/src/vim &>/dev/null
+    mv "vim-${VIM_VERSION}" /usr/local/src/vim
+    pushd "/usr/local/src/vim" &>/dev/null
+      ./configure \
+        --enable-multibyte \
+        --prefix=/usr/local \
+        --with-features=huge \
+        --enable-pythoninterp \
+        --enable-python3interp \
+        --enable-luainterp \
+        --enable-rubyinterp
+      make install
+      echo "${VIM_VERSION}" > /root/.versions/vim
+    popd &>/dev/null
+  popd &>/dev/null
+}

--- a/vim/vim_spec.rb
+++ b/vim/vim_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../tests/spec_helper'
+
+vim_version = '8.0.0022'
+cname = ENV['container_name']
+
+describe command("docker exec #{cname} /usr/local/bin/vim --version") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /VIM - Vi IMproved 8.0/ }
+  its(:stdout) { should match /\+termguicolors/ }
+end
+
+describe command("docker exec #{cname} cat /root/.versions/vim") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{vim_version}/ }
+end

--- a/xfce-theme/README.md
+++ b/xfce-theme/README.md
@@ -1,0 +1,20 @@
+# xfce-theme
+
+[![Build Status](https://travis-ci.org/loliee/install-scripts.svg?branch=master)](https://travis-ci.org/loliee/install-scripts)
+
+Install [axe](https://www.xfce-look.org/content/show.php/axe?content=73291) and
+[lacapitaine](https://github.com/keeferrourke/la-capitaine-icon-theme).
+
+## Dependencies
+
+- `curl`
+
+## Variables
+
+name             | default   | description
+-----------------|-----------|----------------------------------
+`LACAPITAINE_ICON_THEME_VERSION` | `0.3.0` | version to install.
+
+## License
+
+MIT © [Maxime Loliée](https://github.com/loliee/)

--- a/xfce-theme/xfce-theme.sh
+++ b/xfce-theme/xfce-theme.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+CUSER=${CUSER:-'root'}
+LACAPITAINE_ICON_THEME_VERSION=${LACAPITAINE_ICON_THEME_VERSION:-'0.3.0'}
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Ensure version directory exists
+mkdir -p /root/.versions
+
+# Ensure curl is installed
+hash curl &>/dev/null || apt-get install -y curl
+
+if [[ ${CUSER} == 'root' ]]; then
+  user_home='/root'
+else
+  user_home="/home/${CUSER}"
+fi
+
+if [[ ! -d "${user_home}/.local/share/themes/axe rounded" ]]; then
+  echo "--> install xfce axe theme..."
+  curl -L https://dl.opendesktop.org/api/files/download/id/1460767141/73291-axe.tar.gz -o /tmp/xfce-axe.tar.gz
+  mkdir -p "${user_home}/.local/share/themes"
+  pushd "/tmp" &>/dev/null
+    tar xvfz xfce-axe.tar.gz
+    mv axe\ rounded "${user_home}/.local/share/themes/"
+    chown -R "${CUSER}." "${user_home}/.local"
+  popd &>/dev/null
+fi
+
+grep -q "^${LACAPITAINE_ICON_THEME_VERSION}" /root/.versions/lacapitaine &>/dev/null || {
+  if [[ ! -d "${user_home}/.icons/la-capitaine-icon-theme-${LACAPITAINE_ICON_THEME_VERSION}" ]]; then
+    echo "--> install icons theme lacapitaine v${LACAPITAINE_ICON_THEME_VERSION}..."
+    curl -L "https://dl.opendesktop.org/api/files/download/id/1472166359/la-capitaine-icon-theme-${LACAPITAINE_ICON_THEME_VERSION}.tar.gz" \
+      -o "/tmp/lacapitaine-icon-theme-${LACAPITAINE_ICON_THEME_VERSION}.tar.gz"
+    mkdir -p "${user_home}/.icons"
+    pushd "/tmp" &>/dev/null
+      tar xvfz "lacapitaine-icon-theme-${LACAPITAINE_ICON_THEME_VERSION}.tar.gz"
+      mv "la-capitaine-icon-theme-${LACAPITAINE_ICON_THEME_VERSION}" "${user_home}/.icons/la-capitaine-icon-theme-${LACAPITAINE_ICON_THEME_VERSION}"
+      chown -R "${CUSER}." "${user_home}/.icons"
+    popd &>/dev/null
+    echo "${LACAPITAINE_ICON_THEME_VERSION}" >/root/.versions/lacapitaine
+  fi
+}

--- a/xfce-theme/xfce-theme_spec.rb
+++ b/xfce-theme/xfce-theme_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../tests/spec_helper'
+
+lacapitaine_version = '0.3.0'
+cname = ENV['container_name']
+
+describe command("docker exec #{cname} ls /root/.icons/la-capitaine-icon-theme-0.3.0") do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command("docker exec #{cname} cat /root/.versions/lacapitaine") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /#{lacapitaine_version}/ }
+end


### PR DESCRIPTION
## Description

Those scripts are tested on last debian/ubuntu LTS releases.
Each script can be used separetly and will install it's own dependencies.

add following recipies:

- [X] albert
- [X] bats
- [X] docker and docker-compose
- [X] etcd
- [X] flannel
- [X] fzf
- [X] hack-font
- [X] install-ruby (chruby, and ruby 2.3.1)
- [X] kubernetes
- [X] pip
- [X] sshrc
- [X] stow
- [X] tmux
- [X] vagrant
- [X] vim
- [X] xfce-theme

## Tests

Scripts are tested on travis inside docker container and validate with `serverspec`.